### PR TITLE
Remove the initialization of "vqmod_log_separator" outside of the constructor

### DIFF
--- a/upload/clicker_vqmod_manager/admin/model/module/vqmod.php
+++ b/upload/clicker_vqmod_manager/admin/model/module/vqmod.php
@@ -3,7 +3,7 @@ namespace Opencart\Admin\Model\Extension\ClickerVqmodManager\Module;
 class Vqmod extends \Opencart\System\Engine\Model {
 	public $vqmod_dir = 'vqmod';
 	public $vqmod_url = 'vqmod';
-	public $vqmod_log_separator = '----------------------------------------------------------------------';
+	public $vqmod_log_separator;
 
 	public function __construct($registry) {
 		parent::__construct($registry);


### PR DESCRIPTION
Because the property is defined in the constructor (line #11)